### PR TITLE
hotfix/pipe

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,12 +45,12 @@ steps:
   image: "906087756158.dkr.ecr.us-east-1.amazonaws.com/mpn-complete:2020-06-08"
   pull: never
   environment:
-    R_LIBS_USER: "/opt/rpkgs/3.6/"
+    R_LIBS_USER: "/opt/rpkgs/4.0/"
   commands:
     - git config --global user.email "drone@metrumrg.com"
     - git config --global user.name "Drony"
     - git fetch --tags
-    - R -e "pkgpub::create_tagged_repo()"
+    - /opt/R/4.0.1/bin/R R -e "pkgpub::create_tagged_repo()"
     - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/${DRONE_TAG}
     - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/latest_tag
   depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -50,7 +50,7 @@ steps:
     - git config --global user.email "drone@metrumrg.com"
     - git config --global user.name "Drony"
     - git fetch --tags
-    - /opt/R/4.0.1/bin/R R -e "pkgpub::create_tagged_repo()"
+    - /opt/R/4.0.1/bin/R -e "pkgpub::create_tagged_repo()"
     - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/${DRONE_TAG}
     - aws s3 sync /tmp/${DRONE_TAG} s3://mpn.metworx.dev/releases/${DRONE_REPO_NAME}/latest_tag
   depends_on:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,5 @@ Suggests:
     sessioninfo,
     testthat (>= 2.1.0),
     withr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 VignetteBuilder: knitr

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -1,6 +1,6 @@
 #' Pipe operator
 #'
-#' See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+#' See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
 #'
 #' @name %>%
 #' @rdname pipe

--- a/man/pipe.Rd
+++ b/man/pipe.Rd
@@ -7,6 +7,6 @@
 lhs \%>\% rhs
 }
 \description{
-See \code{magrittr::\link[magrittr]{\%>\%}} for details.
+See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
 }
 \keyword{internal}

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -4,7 +4,7 @@ describe("issue functions", {
 
 	test_that("it can get repo issues", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issues_response.json"))
 			},
 			get_repo_issues("test", "test")
@@ -17,7 +17,7 @@ describe("issue functions", {
 
 	test_that("it can get repo issue labels", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issue_labels_response.json"))
 			},
 			get_repo_issue_labels("test", "test")
@@ -30,7 +30,7 @@ describe("issue functions", {
 
 	test_that("it can get repo issue assignees", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issue_assignees_response.json"))
 			},
 			get_issue_assignees("test", "test")
@@ -43,7 +43,7 @@ describe("issue functions", {
 
 	test_that("it can get issue events", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issue_events_response.json"))
 			},
 			get_issue_events("test", "test")
@@ -56,7 +56,7 @@ describe("issue functions", {
 
 	test_that("it can get issue comments", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issue_comments_response.json"))
 			},
 			get_issue_comments("test", "test")
@@ -69,7 +69,7 @@ describe("issue functions", {
 
 	test_that("it can get issues by a specific milestone", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("issues/issue_milestone_response.json"))
 			},
 			get_issues_from_milestone("test", "test", 5)

--- a/tests/testthat/test-projectboard.R
+++ b/tests/testthat/test-projectboard.R
@@ -4,7 +4,7 @@ describe("projectboard functions", {
 
 	test_that("it can get projectboard info", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("projectboard/projectboard_info_response.json"))
 			},
 			get_projectboard_info("test", "test")
@@ -17,7 +17,7 @@ describe("projectboard functions", {
 
 	test_that("it can get projectboard data", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("projectboard/projectboard_response.json"))
 			},
 			get_projectboard("test", "test")

--- a/tests/testthat/test-pullrequests.R
+++ b/tests/testthat/test-pullrequests.R
@@ -4,7 +4,7 @@ describe("pull request functions", {
 
 	test_that("it can get pull request commits", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("pullrequests/pull_request_commits_response.json"))
 			},
 			get_pull_request_commits("test", "test")
@@ -17,7 +17,7 @@ describe("pull request functions", {
 
 	test_that("it can get all pull requests", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("pullrequests/all_pull_requests_response.json"))
 			},
 			get_all_pull_requests("test", "test")
@@ -30,7 +30,7 @@ describe("pull request functions", {
 
 	test_that("it can get all pull request reviewers", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("pullrequests/pull_request_reviewers_response.json"))
 			},
 			get_pull_request_reviewers("test", "test")
@@ -43,7 +43,7 @@ describe("pull request functions", {
 
 	test_that("it can get all pull request comments", {
 		result <- with_mock(
-			graphql_query = function(file, ..., .api_url, .header) {
+			"ghpm::graphql_query" = function(file, ..., .api_url, .header) {
 				return(jsonlite::read_json("pullrequests/pull_request_comments_response.json"))
 			},
 			get_pull_request_comments("test", "test", 111)


### PR DESCRIPTION
This PR fixes the [CI error](https://github-drone.metrumrg.com/metrumresearchgroup/ghpm/7/1/3) related to `%>%`:
```
Functions or methods with usage in documentation object '%>%' but not in code: ‘%>%’
```
I'm not entirely sure why this error was thrown for R 3.6 but not 4.0, but it may be related to [this change](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16662). In particular, re-running `usethis::use_pipe()` results in a different link, which follows [these conventions](http://r-pkgs.had.co.nz/man.html#text-formatting).

FYI @dpastoor @seth127 