### PR TITLE
Release/0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ghpm
 Type: Package
 Title: GHPM
 Description: Github Project Manager
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: 
 	person( given = "Harsh",
 			family = "Baid",
@@ -16,7 +16,7 @@ Imports:
     magrittr,
     dplyr,
     readr,
-    gh,
+    gh (>= 1.2.0),
     tibble,
     stringr,
     glue,

--- a/R/ghpm.R
+++ b/R/ghpm.R
@@ -31,7 +31,7 @@ graphql_query <- function(file, ..., .api_url = api_url(), .header = NULL) {
 	}
 	query <- readChar(file, file.info(file)$size)
 
-	return(gh("POST ", query = query, variables = compact(list(...)), .send_headers = .header, .api_url = .api_url, .token = get_token(.api_url)))
+	return(gh("POST {url}", url = .api_url, query = query, variables = compact(list(...)), .send_headers = .header, .token = get_token(.api_url)))
 }
 
 #' Helper function for validating tokens

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -20,7 +20,7 @@ Packages:
   - pingr
 
 Repos:
-  - MPN: https://mpn.metworx.com/snapshots/stable/2020-06-08/
+  - MPN: https://mpn.metworx.com/snapshots/stable/2020-11-21
 
 Customizations:
   Packages:

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -20,7 +20,7 @@ Packages:
   - pingr
 
 Repos:
-  - MPN: https://mpn.metworx.com/snapshots/stable/2020-11-21
+  - MPN: https://mpn.metworx.com/snapshots/stable/2020-12-21
 
 Customizations:
   Packages:


### PR DESCRIPTION
This release resolves any breaking changes that came as a result of the GH 1.2.0 release. 

@seth127 @copernican If you could test this out and confirm that it is working as intended before I merge and publish the release